### PR TITLE
Add validation plugin

### DIFF
--- a/sunbeam-python/requirements.txt
+++ b/sunbeam-python/requirements.txt
@@ -36,5 +36,8 @@ lightkube-models
 jsonschema
 GitPython
 
+# For plugin validation
+croniter
+
 # Regression introduced in 1.3.3
 macaroonbakery!=1.3.3

--- a/sunbeam-python/sunbeam/plugins/observability/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/observability/plugin.py
@@ -161,6 +161,94 @@ class RemoveObservabilityIntegrationStep(BaseStep):
         return Result(ResultType.COMPLETED)
 
 
+class FillGrafanaAgentK8sEndpointStep(BaseStep):
+    """Update terraform plan to fill grafana-agent-k8s endpoints."""
+
+    def __init__(
+        self,
+        client: Client,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+    ) -> None:
+        super().__init__(
+            "Fill Grafana Agent K8s Endpoints",
+            "Filling Grafana agent K8s Endpoints in Openstack",
+        )
+        self.client = client
+        self.tfhelper = tfhelper
+        self.jhelper = jhelper
+        self.model = OPENSTACK_MODEL
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Apply terraform configuration"""
+        config_key = OPENSTACK_TERRAFORM_VARS
+
+        try:
+            tfvars = read_config(self.client, config_key)
+        except ConfigItemNotFoundException:
+            tfvars = {}
+
+        # Fill grafana-agent-k8s's endpoints in openstack model
+        tfvars.update(
+            {
+                "metrics-endpoint": "metrics-endpoint",
+                "logging-provider": "logging-provider",
+                "grafana-dashboards-consumer": "grafana-dashboards-consumer",
+            }
+        )
+        update_config(self.client, config_key, tfvars)
+        self.tfhelper.write_tfvars(tfvars)
+
+        try:
+            self.tfhelper.apply()
+        except TerraformException as e:
+            return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)
+
+
+class RemoveGrafanaAgentK8sEndpointStep(BaseStep):
+    """Update terraform plan to remove grafana-agent-k8s endpoints."""
+
+    def __init__(
+        self,
+        client: Client,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+    ) -> None:
+        super().__init__(
+            "Remove Grafana Agent K8s Endpoints",
+            "Removing Grafana agent K8s Endpoints in Openstack",
+        )
+        self.client = client
+        self.tfhelper = tfhelper
+        self.jhelper = jhelper
+        self.model = OPENSTACK_MODEL
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Apply terraform configuration"""
+        config_key = OPENSTACK_TERRAFORM_VARS
+
+        try:
+            tfvars = read_config(self.client, config_key)
+        except ConfigItemNotFoundException:
+            tfvars = {}
+
+        # Remove grafana-agent-k8s's endpoints in openstack model
+        tfvars.pop("metrics-endpoint", None)
+        tfvars.pop("logging-provider", None)
+        tfvars.pop("grafana-dashboards-consumer", None)
+        update_config(self.client, config_key, tfvars)
+        self.tfhelper.write_tfvars(tfvars)
+
+        try:
+            self.tfhelper.apply()
+        except TerraformException as e:
+            return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)
+
+
 class DeployObservabilityStackStep(BaseStep, JujuStepHelper):
     """Deploy Observability Stack using Terraform"""
 
@@ -564,7 +652,9 @@ class PatchCosLoadBalancerStep(PatchLoadBalancerServicesStep):
 
 class ObservabilityPlugin(EnableDisablePlugin):
     version = Version("0.0.1")
-    requires = {PluginRequirement("telemetry", optional=True)}
+    requires = {
+        PluginRequirement("telemetry", optional=True),
+    }
 
     def __init__(self, client: Client) -> None:
         super().__init__("observability", client)
@@ -638,6 +728,7 @@ class ObservabilityPlugin(EnableDisablePlugin):
             DeployGrafanaAgentK8sStep(
                 self, tfhelper_grafana_agent_k8s, tfhelper_cos, jhelper
             ),
+            FillGrafanaAgentK8sEndpointStep(tfhelper_openstack, jhelper),
         ]
 
         run_plan(cos_plan, console)
@@ -694,6 +785,7 @@ class ObservabilityPlugin(EnableDisablePlugin):
 
         grafana_agent_k8s_plan = [
             TerraformInitStep(tfhelper_grafana_agent_k8s),
+            RemoveGrafanaAgentK8sEndpointStep(self.client, tfhelper_openstack, jhelper),
             RemoveGrafanaAgentK8sStep(
                 self, tfhelper_grafana_agent_k8s, tfhelper_cos, jhelper
             ),
@@ -715,7 +807,7 @@ class ObservabilityPlugin(EnableDisablePlugin):
         super().disable_plugin()
 
     @click.group()
-    def observability_group(self):
+    def observability_group(self) -> None:
         """Manage Observability."""
 
     @click.command()

--- a/sunbeam-python/sunbeam/plugins/plugins.yaml
+++ b/sunbeam-python/sunbeam/plugins/plugins.yaml
@@ -67,3 +67,9 @@ sunbeam-plugins:
       path: sunbeam.plugins.ldap.plugin.LDAPPlugin
       supported_architectures:
         - amd64
+    - name: "validation"
+      version: "0.0.1"
+      description: "Plugin for integrating with tempest"
+      path: sunbeam.plugins.validation.plugin.ValidationPlugin
+      supported_architectures:
+        - amd64

--- a/sunbeam-python/sunbeam/plugins/validation/README.md
+++ b/sunbeam-python/sunbeam/plugins/validation/README.md
@@ -1,0 +1,27 @@
+# Validation
+
+This plugin provides OpenStack Integration Test Suite: tempest for Sunbeam. It is based on [tempest-k8s](https://opendev.org/openstack/sunbeam-charms/src/branch/main/charms/tempest-k8s) and [tempest-rock](https://github.com/canonical/ubuntu-openstack-rocks/tree/main/rocks/tempest) project.
+
+## Installation
+
+To enable cloud validation, you need an already bootstrapped Sunbeam instance. Then, you can install the plugin with:
+
+```bash
+sunbeam enable validation
+```
+
+This plugin is also related to `observability` plugin.
+
+## Contents
+
+This plugin will install [tempest-k8s](https://opendev.org/openstack/sunbeam-charms/src/branch/main/charms/tempest-k8s), and provide command line interface: `sunbeam validate`, `sunbeam validation-lists`, and `sunbeam configure validation` (disabled) to your Sunbeam deployment.
+
+Additionally, if you enable `observability` plugin, you will also get periodic cloud validation feature from this plugin. You can configure the periodic validation schedule using `sunbeam configure validation`. The periodic cloud validation results can be seen in the Grafana dashboard.
+
+## Removal
+
+To remove the plugin, run:
+
+```bash
+sunbeam disable validation
+```

--- a/sunbeam-python/sunbeam/plugins/validation/README.md
+++ b/sunbeam-python/sunbeam/plugins/validation/README.md
@@ -14,7 +14,7 @@ This plugin is also related to `observability` plugin.
 
 ## Contents
 
-This plugin will install [tempest-k8s](https://opendev.org/openstack/sunbeam-charms/src/branch/main/charms/tempest-k8s), and provide command line interface: `sunbeam validate`, `sunbeam validation-lists`, and `sunbeam configure validation` (disabled) to your Sunbeam deployment.
+This plugin will install [tempest-k8s](https://opendev.org/openstack/sunbeam-charms/src/branch/main/charms/tempest-k8s), and provide command line interface: `sunbeam validate`, `sunbeam validation-lists`, and `sunbeam configure validation` (this command will only be useful if you enable `observability` plugin) to your Sunbeam deployment.
 
 Additionally, if you enable `observability` plugin, you will also get periodic cloud validation feature from this plugin. You can configure the periodic validation schedule using `sunbeam configure validation`. The periodic cloud validation results can be seen in the Grafana dashboard.
 

--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -159,12 +159,12 @@ class ValidationPlugin(OpenStackControlPlanePlugin):
 
     @click.command()
     def enable_plugin(self) -> None:
-        """Enable OpenStack Telemetry applications."""
+        """Enable OpenStack Integration Test Suite (tempest)."""
         super().enable_plugin()
 
     @click.command()
     def disable_plugin(self) -> None:
-        """Disable OpenStack Telemetry applications."""
+        """Disable OpenStack Integration Test Suite (tempest)."""
         super().disable_plugin()
 
     @click.command()

--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -1,0 +1,304 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+import click
+from croniter import croniter
+from packaging.version import Version
+from rich.console import Console
+
+from sunbeam.clusterd.client import Client
+from sunbeam.clusterd.service import ClusterServiceUnavailableException
+from sunbeam.commands.openstack import OPENSTACK_MODEL
+from sunbeam.jobs.juju import JujuHelper, run_sync
+from sunbeam.plugins.interface.v1.openstack import (
+    OpenStackControlPlanePlugin,
+    TerraformPlanLocation,
+)
+
+LOG = logging.getLogger(__name__)
+console = Console()
+
+PLUGIN_VERSION = "0.0.1"
+MINIMAL_PERIOD = 15 * 60
+TEMPEST_CHANNEL = "latest/edge"
+VALIDATION_PLUGIN_DEPLOY_TIMEOUT = 60 * 60  # tempest can take some time to initialized
+
+
+def validate_schedule(schedule: str) -> tuple[bool, Optional[str]]:
+    """Validate if the schedule config option is validate or not."""
+    # Empty schedule is fine; it means it's disabled in this context.
+    if not schedule:
+        return True, "Schedule is an empty string, disabling the periodic check."
+
+    # croniter supports second repeats, but vixie cron does not.
+    if len(schedule.split()) == 6:
+        return False, "This cron does not support seconds in schedule (6 fields)."
+
+    # constant base time for consistency
+    base = datetime(2004, 3, 5)
+
+    try:
+        cron = croniter(schedule, base, max_years_between_matches=1)
+    except ValueError as e:
+        msg = str(e)
+        # croniter supports second repeats, but vixie cron does not,
+        # so update the error message here to suit.
+        if "Exactly 5 or 6 columns" in msg:
+            msg = "Exactly 5 columns must be specified for iterator expression."
+        return False, msg
+
+    # This is a rather naive method for enforcing this,
+    # and it may be possible to craft an expression
+    # that results in some consecutive runs within 15 minutes,
+    # however this is fine, as there is process locking for tempest,
+    # and this is more of a sanity check than a security requirement.
+    t1 = cron.get_next()
+    t2 = cron.get_next()
+    if t2 - t1 <= MINIMAL_PERIOD:
+        return False, "Schedule repeats faster than 15 minutes."
+
+    return True, f"Setting schedule to {schedule}"
+
+
+class ValidationPlugin(OpenStackControlPlanePlugin):
+    """Deploy tempest to openstack model."""
+
+    version = Version(PLUGIN_VERSION)
+
+    def __init__(self, client: Client) -> None:
+        """Initialize the plugin class."""
+        super().__init__(
+            "validation",
+            client,
+            tf_plan_location=TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO,
+        )
+
+    def set_application_names(self) -> list:
+        """Application names handled by the terraform plan."""
+        return ["tempest"]
+
+    def set_tfvars_on_enable(self) -> dict:
+        """Set terraform variables to enable the application."""
+        return {
+            "enable-validation": True,
+            "tempest-channel": TEMPEST_CHANNEL,
+        }
+
+    def set_application_timeout_on_enable(self) -> int:
+        """Set Application Timeout on enabling the plugin.
+
+        The plugin plan will timeout if the applications
+        are not in active status within in this time.
+        """
+        return VALIDATION_PLUGIN_DEPLOY_TIMEOUT
+
+    def set_application_timeout_on_disable(self) -> int:
+        """Set Application Timeout on disabling the plugin.
+
+        The plugin plan will timeout if the applications
+        are not removed within this time.
+        """
+        return VALIDATION_PLUGIN_DEPLOY_TIMEOUT
+
+    def set_tfvars_on_disable(self) -> dict:
+        """Set terraform variables to disable the application."""
+        return {"enable-validation": False}
+
+    def set_tfvars_on_resize(self) -> dict:
+        """Set terraform variables to resize the application."""
+        return {}
+
+    def _run_action(
+        self,
+        action_name: str,
+        action_params: Optional[dict] = None,
+        progress_message: str = "",
+        print_stdout: bool = False,
+    ) -> None:
+        """Run the charm's action."""
+        jhelper = JujuHelper(self.client, self.snap.paths.user_data)
+        with console.status(progress_message):
+            app = "tempest"
+            model = OPENSTACK_MODEL
+            unit = run_sync(jhelper.get_leader_unit(app, model))
+            if not unit:
+                message = f"Unable to get {app} leader"
+                raise click.ClickException(message)
+
+            action_result = run_sync(
+                jhelper.run_action(
+                    unit,
+                    model,
+                    action_name,
+                    action_params or {},
+                )
+            )
+
+            if action_result.get("return-code", 0) > 1:
+                message = f"Unable to run action: {action_name}"
+                raise click.ClickException(message)
+
+            if print_stdout:
+                console.print(action_result.get("stdout").strip())
+
+    @click.command()
+    def enable_plugin(self) -> None:
+        """Enable OpenStack Telemetry applications."""
+        super().enable_plugin()
+
+    @click.command()
+    def disable_plugin(self) -> None:
+        """Disable OpenStack Telemetry applications."""
+        super().disable_plugin()
+
+    @click.command()
+    @click.option(
+        "-s",
+        "--schedule",
+        default="",
+        help=(
+            "The cron schedule expression to define when to run tempest"
+            " periodic checks. When the value is empty (default),"
+            " period checks will be disabled."
+        ),
+    )
+    def configure_validation(self, schedule: str = "") -> None:
+        """Configure validation plugin."""
+        jhelper = JujuHelper(self.client, self.snap.paths.user_data)
+        with console.status("Configuring validation plugin ..."):
+            valid, message = validate_schedule(schedule)
+            if not valid:
+                raise click.ClickException(message)
+
+            app = "tempest"
+            model = OPENSTACK_MODEL
+            unit = run_sync(jhelper.get_leader_unit(app, model))
+            if not unit:
+                message = f"Unable to get {app} leader"
+                raise click.ClickException(message)
+
+            run_sync(
+                jhelper.set_application_config(
+                    model, app, config={"schedule": schedule}
+                )
+            )
+            console.print(message)
+
+    @click.command()
+    @click.option(
+        "-s",
+        "--smoke",
+        is_flag=True,
+        default=False,
+        help="Run the smoke tests only. Equivalent to --regex=smoke.",
+    )
+    @click.option(
+        "-r",
+        "--regex",
+        default="",
+        help=(
+            "A list of regexes, whitespace separated, used to select tests from"
+            " the list."
+        ),
+    )
+    @click.option(
+        "-e",
+        "--exclude-regex",
+        default="",
+        help="A single regex to exclude tests.",
+    )
+    @click.option(
+        "-t",
+        "--serial",
+        is_flag=True,
+        default=False,
+        help="Run tests serially. By default, tests run in parallel.",
+    )
+    @click.option(
+        "--test-list",
+        default="",
+        help=(
+            "Use a predefined test list. See `sunbeam validation-lists`"
+            " for available test lists."
+        )
+    )
+    def run_validate_action(
+        self,
+        smoke: bool = False,
+        regex: str = "",
+        exclude_regex: str = "",
+        serial: bool = False,
+        test_list: str = "",
+    ) -> None:
+        """Validate the sunbeam installation."""
+        action_name = "validate"
+        action_params = {
+            "regex": "smoke" if smoke else regex,
+            "exclude-regex": exclude_regex,
+            "serial": serial,
+            "test-list": test_list,
+        }
+        progress_message = "Running tempest to validate the sunbeam deployment ..."
+        self._run_action(
+            action_name,
+            action_params=action_params,
+            progress_message=progress_message,
+            print_stdout=True,
+        )
+
+    @click.command()
+    def run_get_lists_action(self) -> None:
+        """Get supported test lists for validation."""
+        action_name = "get-lists"
+        progress_message = "Retrieving existing test lists from tempest charm ..."
+        self._run_action(
+            action_name,
+            action_params={},
+            progress_message=progress_message,
+            print_stdout=True,
+        )
+
+    def commands(self) -> dict:
+        """Dict of clickgroup along with commands."""
+        commands = super().commands()
+        try:
+            enabled = self.enabled
+        except ClusterServiceUnavailableException:
+            LOG.debug(
+                "Failed to query for plugin status, is cloud bootstrapped ?",
+                exc_info=True,
+            )
+            enabled = False
+
+        if enabled:
+            commands.update(
+                {
+                    "init": [
+                        {"name": "validate", "command": self.run_validate_action},
+                        {
+                            "name": "validation-lists",
+                            "command": self.run_get_lists_action,
+                        },
+                    ],
+                    "configure": [
+                        {"name": "validation", "command": self.configure_validation},
+                    ],
+                }
+            )
+        return commands

--- a/sunbeam-python/test-requirements.txt
+++ b/sunbeam-python/test-requirements.txt
@@ -18,3 +18,6 @@ openstacksdk # Apache-2.0
 pytest
 pytest-mock
 pytest-asyncio
+
+# For validation plugin
+croniter

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
@@ -39,6 +39,14 @@ def mock_run_sync(mocker):
     loop.close()
 
 
+@pytest.fixture(autouse=True)
+def mock_read_config(mocker):
+    def read_config(client, config_key):
+        return {}
+
+    mocker.patch("sunbeam.plugins.observability.plugin.read_config", read_config)
+
+
 @pytest.fixture()
 def cclient():
     with patch("sunbeam.plugins.interface.v1.base.Client") as p:
@@ -323,3 +331,65 @@ class TestRemoveGrafanaAgentK8sStep:
         jhelper.wait_application_gone.assert_called_once()
         assert result.result_type == ResultType.FAILED
         assert result.message == "timed out"
+
+
+class TestFillGrafanaAgentK8sEndpointStep:
+    def test_run(self, cclient, jhelper, tfhelper, observabilityplugin):
+        step = observability_plugin.FillGrafanaAgentK8sEndpointStep(
+            cclient, tfhelper, jhelper
+        )
+        result = step.run()
+
+        tfhelper.write_tfvars.assert_called_once()
+        tfhelper.apply.assert_called_once()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_tf_destroy_failed(
+        self, cclient, jhelper, tfhelper, observabilityplugin
+    ):
+        tfhelper.apply.side_effect = TerraformException("apply failed...")
+
+        step = observability_plugin.FillGrafanaAgentK8sEndpointStep(
+            cclient, tfhelper, jhelper
+        )
+        result = step.run()
+
+        # Make sure they are in the code
+        endpoints = {
+            "metrics-endpoint": "metrics-endpoint",
+            "logging-provider": "logging-provider",
+            "grafana-dashboards-consumer": "grafana-dashboards-consumer",
+        }
+        tfhelper.write_tfvars.assert_called_once_with(endpoints)
+        tfhelper.apply.assert_called_once()
+        assert result.result_type == ResultType.FAILED
+        assert result.message == "apply failed..."
+
+
+class TestRemoveGrafanaAgentK8sEndpointStep:
+    def test_run(self, cclient, jhelper, tfhelper, observabilityplugin):
+        step = observability_plugin.RemoveGrafanaAgentK8sEndpointStep(
+            cclient, tfhelper, jhelper
+        )
+        result = step.run()
+
+        tfhelper.write_tfvars.assert_called_once()
+        tfhelper.apply.assert_called_once()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_tf_destroy_failed(
+        self, cclient, jhelper, tfhelper, observabilityplugin
+    ):
+        tfhelper.apply.side_effect = TerraformException("apply failed...")
+
+        step = observability_plugin.RemoveGrafanaAgentK8sEndpointStep(
+            cclient, tfhelper, jhelper
+        )
+        result = step.run()
+
+        # Make sure they are removed
+        endpoints = {}
+        tfhelper.write_tfvars.assert_called_once_with(endpoints)
+        tfhelper.apply.assert_called_once()
+        assert result.result_type == ResultType.FAILED
+        assert result.message == "apply failed..."

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
@@ -80,7 +80,7 @@ class TestValidatorFunction:
     @pytest.mark.parametrize(
         "test_input,expected_output",
         [
-            ("*/5 * * * *", (False, "Schedule repeats faster")),
+            ("*/5 * * * *", (False, "Cannot schedule periodic check")),
             ("*/30 * * * * 6", (False, "This cron does not support")),
             ("*/30 * *", (False, "Exactly 5 columns must")),
             ("*/5 * * * xyz", (False, "not acceptable")),

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
@@ -1,0 +1,94 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from sunbeam.plugins.validation import plugin as validation_plugin
+
+
+@pytest.fixture(autouse=True)
+def mock_run_sync(mocker):
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+
+    def run_sync(coro):
+        return loop.run_until_complete(coro)
+
+    mocker.patch("sunbeam.plugins.validation.plugin.run_sync", run_sync)
+    yield
+    loop.close()
+
+
+@pytest.fixture()
+def cclient():
+    with patch("sunbeam.plugins.interface.v1.base.Client") as p:
+        yield p
+
+
+@pytest.fixture()
+def jhelper():
+    yield AsyncMock()
+
+
+@pytest.fixture()
+def tfhelper():
+    yield Mock(path=Path())
+
+
+@pytest.fixture()
+def validationplugin():
+    with patch("sunbeam.plugins.validation.plugin.ValidationPlugin") as p:
+        yield p
+
+
+class TestValidatorFunction:
+    """Test validator functions."""
+
+    @pytest.mark.parametrize(
+        "test_input,expected_output",
+        [
+            ("", (True, "Schedule is an empty string")),
+            ("5 4 * * *", (True, "Setting schedule to")),
+            ("5 4 * * mon", (True, "Setting schedule to")),
+            ("*/30 * * * *", (True, "Setting schedule to")),
+        ],
+    )
+    def test_valid_cron_expressions(self, test_input, expected_output):
+        """Verify valid cron expressions."""
+        success, message = validation_plugin.validate_schedule(test_input)
+        expected_success, expected_message = expected_output
+        assert success == expected_success
+        assert expected_message in message
+
+    @pytest.mark.parametrize(
+        "test_input,expected_output",
+        [
+            ("*/5 * * * *", (False, "Schedule repeats faster")),
+            ("*/30 * * * * 6", (False, "This cron does not support")),
+            ("*/30 * *", (False, "Exactly 5 columns must")),
+            ("*/5 * * * xyz", (False, "not acceptable")),
+        ],
+    )
+    def test_invalid_cron_expressions(self, test_input, expected_output):
+        """Verify invalid cron expressions."""
+        success, message = validation_plugin.validate_schedule(test_input)
+        expected_success, expected_message = expected_output
+        assert success == expected_success
+        assert expected_message in message


### PR DESCRIPTION
This PR add validation plugin which deploys tempest-k8s in the openstack model, and fill necessary relation to grafana-agent-k8s. 

- Add tempest-k8s application
- Add relations to keystone-k8s
  - keystone:identity-ops                                           tempest:identity-ops
- Add relations to grafana-agent-k8s (if observability plugin is enabled)
  - tempest:grafana-dashboard                                grafana-agent-k8s:grafana-dashboards-consumer
  - grafana-agent-k8s:logging-provider                    tempest:logging
- Added placeholder subcommands
  - `sunbeam validate`
  - `sunbeam validation-lists`
  - `sunbeam configure validation`

Depends: #1 and https://github.com/agileshaw/sunbeam-terraform/pull/1