### PR TITLE
Move validation commands into group

### DIFF
--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -280,7 +280,7 @@ class ValidationPlugin(OpenStackControlPlanePlugin):
         "--smoke",
         is_flag=True,
         default=False,
-        help="Run the smoke tests only. Equivalent to --regex=smoke.  If --regex and --smoke are provided, --regex is ignored.",
+        help="Run the smoke tests only. Equivalent to --regex=smoke.  If both --regex and --smoke are provided, --regex is ignored.",
     )
     @click.option(
         "-r",


### PR DESCRIPTION
[BSENG-2024](https://warthogs.atlassian.net/browse/BSENG-2024)



<details>
<summary>Examples for reference:</summary>

```
ubuntu@serverstack-sunbeam-0:~$ openstack.sunbeam validation
Usage: sunbeam validation [OPTIONS] COMMAND [ARGS]...

  Manage cloud validation functionality.

Options:
  -h, --help  Show this message and exit.

Commands:
  run         Run a set of tests on the sunbeam installation.
  test-lists  Get supported test lists for validation.


ubuntu@serverstack-sunbeam-0:~$ openstack.sunbeam validation run --help
Usage: sunbeam validation run [OPTIONS]

  Run a set of tests on the sunbeam installation.

Options:
  -s, --smoke               Run the smoke tests only. Equivalent to
                            --regex=smoke.  If --regex and --smoke are
                            provided, --regex is ignored.
  -r, --regex TEXT          A list of regexes, whitespace separated, used to
                            select tests from the list.
  -e, --exclude-regex TEXT  A single regex to exclude tests.
  -t, --serial              Run tests serially. By default, tests run in
                            parallel.
  -l, --test-list TEXT      Use a predefined test list. See `sunbeam
                            validation-lists` for available test lists.
  -h, --help                Show this message and exit.


ubuntu@serverstack-sunbeam-0:~$ openstack.sunbeam validation test-lists --help
Usage: sunbeam validation test-lists [OPTIONS]

  Get supported test lists for validation.

Options:
  -h, --help  Show this message and exit.



ubuntu@serverstack-sunbeam-0:~$ openstack.sunbeam configure -h
Usage: sunbeam configure [OPTIONS] COMMAND [ARGS]...

  Configure cloud with some sensible defaults.

Options:
  -a, --accept-defaults  Accept all defaults.
  -p, --preseed FILE     Preseed file.
  -o, --openrc FILE      Output file for cloud access details.
  -h, --help             Show this message and exit.

Commands:
  caas        Configure Cloud for Container as a Service use.
  validation  Configure validation plugin.


ubuntu@serverstack-sunbeam-0:~$ openstack.sunbeam configure validation
Config options available:

schedule: set a cron schedule for running periodic tests.  Empty disables.

Run with key=value args to set configuration values.
For example: sunbeam configure validation schedule="*/30 * * * *"



ubuntu@serverstack-sunbeam-0:~$ openstack.sunbeam configure validation schedule="foo"
Error: Exactly 5 columns must be specified for iterator expression.
ubuntu@serverstack-sunbeam-0:~$ openstack.sunbeam configure validation schedule="* * * * *"
Error: Cannot schedule periodic check to run faster than every 15 minutes.
ubuntu@serverstack-sunbeam-0:~$ openstack.sunbeam configure validation schedule
Error: syntax: key=value
ubuntu@serverstack-sunbeam-0:~$ openstack.sunbeam configure validation test=something
Error: test is not a supported config option

```

</details>